### PR TITLE
Updated copy to incorporate organization name change.

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ _Stay tuned for updates about other upcoming events & event types!_
   
 ### Participation
 
-The Open Web Application Security Project (OWASP) is a not-for-profit, worldwide organization focused on improving the security of application software. Our mission is to make application security visible, so that people and organizations can make informed decisions about true application security risks. Everyone is free to participate in OWASP and all of our materials are available under a free and open software license.
+The Open Worldwide Application Security Project (OWASP) is a not-for-profit, worldwide organization focused on improving the security of application software. Our mission is to make application security visible, so that people and organizations can make informed decisions about true application security risks. Everyone is free to participate in OWASP and all of our materials are available under a free and open software license.
 
 Become an OWASP Member TODAY [owasp.org/membership](https://owasp.org/membership)
 


### PR DESCRIPTION
On [February 15, 2023](https://owasp.org/www-board/meetings-historical/202302.15), the OWASP Global Board voted to change the OWASP® backronym officially from Web to Worldwide. “Resolved that the Foundation will change all current and future references of the ‘Open Web Application Security Project’ to the ‘Open Worldwide Application Security Project.”