### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/migrated_content.md
+++ b/migrated_content.md
@@ -993,7 +993,7 @@ Time: 6 o’clock.
         show the areas in .Net and Asp.Net applications that are
         vulnerable to Buffer Overflows (including the demo of a .Net
         Buffer Overflow Fuzzer).
-      - **OWASP, the Open Web Application Security Project** - The Open
+      - **OWASP, the Open Worldwide Application Security Project** - The Open
         Web Application Security Project (OWASP) is an open community
         dedicated to enabling organizations to develop, purchase, and
         maintain applications that can be trusted. All of the OWASP


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)